### PR TITLE
refactor: Use named ports - popeye policy POP-108

### DIFF
--- a/charts/aspire-dashboard/templates/deployment.yaml
+++ b/charts/aspire-dashboard/templates/deployment.yaml
@@ -65,7 +65,9 @@ spec:
                 name: {{ include "app.name" . }}-config
           ports:
             - containerPort: {{ .Values.ui.port }}
+              name: ui
             - containerPort: {{ .Values.otlp.port }}
+              name: otlp
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/aspire-dashboard/templates/otlp_clusterip.yaml
+++ b/charts/aspire-dashboard/templates/otlp_clusterip.yaml
@@ -13,7 +13,8 @@ spec:
   selector:
     app: {{ $name }}
   ports:
-    - protocol: TCP
+    - name: otlp
+      protocol: TCP
       port: {{ .Values.otlp.clusterip.port }}
-      targetPort: {{ .Values.otlp.port }}
+      targetPort: otlp
 {{- end }}

--- a/charts/aspire-dashboard/templates/otlp_ingress.yaml
+++ b/charts/aspire-dashboard/templates/otlp_ingress.yaml
@@ -26,7 +26,7 @@ spec:
               service:
                 name: {{ $name }}-otlp-clusterip
                 port:
-                  number: {{ .Values.otlp.clusterip.port }}
+                  name: otlp
   {{- if .Values.otlp.ingress.tls }}
   tls:
   {{- toYaml .Values.otlp.ingress.tls | nindent 4 }}

--- a/charts/aspire-dashboard/templates/ui_clusterip.yaml
+++ b/charts/aspire-dashboard/templates/ui_clusterip.yaml
@@ -13,7 +13,8 @@ spec:
   selector:
     app: {{ $name }}
   ports:
-    - protocol: TCP
+    - name: ui
+      protocol: TCP
       port: {{ .Values.ui.port }}
-      targetPort: {{ .Values.ui.port }}
+      targetPort: ui
 {{- end }}

--- a/charts/aspire-dashboard/templates/ui_ingress.yaml
+++ b/charts/aspire-dashboard/templates/ui_ingress.yaml
@@ -26,7 +26,7 @@ spec:
               service:
                 name: {{ $name }}-ui-clusterip
                 port:
-                  number: {{ .Values.ui.port }}
+                  name: ui
   {{- if .Values.ui.ingress.tls }}
   tls:
   {{- toYaml .Values.ui.ingress.tls | nindent 4 }}


### PR DESCRIPTION
This PR introduces named ports across the Deployment, Services, and Ingress definitions for both UI and OTLP components.
Internally all our clusters adhere to [Popeye](https://github.com/derailed/popeye) policies

Why
	•	Aligns with Popeye policy [POP-108](https://github.com/derailed/popeye/blob/master/docs/codes.md) (named ports required).
	•	Improves clarity and maintainability (ui, otlp instead of raw numbers).
	•	Allows Ingress and Service resources to reference ports symbolically, making future port changes less error-prone.

Changes
	•	Deployment: added name: ui and name: otlp to container ports.
	•	Service: defined named Service ports (ui, otlp) and updated targetPort to use container port names.
	•	Ingress: updated to reference Service port names instead of numbers.

Outcome
	•	Linter warnings resolved (no more “container uses port number”).
	•	Clearer manifests that are easier to read and maintain.